### PR TITLE
Remove Partition Key Version Confusion

### DIFF
--- a/articles/cosmos-db/large-partition-keys.md
+++ b/articles/cosmos-db/large-partition-keys.md
@@ -16,7 +16,7 @@ Large partition keys are supported by using the functionality of an enhanced ver
 
 ## Create a large partition key (Azure portal)
 
-To create a large partition key, while you create a new container using the Azure portal, check the **My partition key is larger than 100-bytes** option. By default, all the new containers are opted into using the large partition keys. Unselect the checkbox if you don’t need large partition keys or if you have applications running on SDKs version older than 1.18.
+To create a large partition key, when you create a new container using the Azure portal, check the **My partition key is larger than 100-bytes** option. Unselect the checkbox if you don’t need large partition keys or if you have applications running on SDKs version older than 1.18.
 
 ![Create large partition keys using Azure portal](./media/large-partition-keys/large-partition-key-with-portal.png)
 


### PR DESCRIPTION
The line "By default, all the new containers are opted into using the large partition keys" implies that partition keys are created as V2 by default however;  The default option in the Azure Portal is V1 partition (unless you check "My partition key is larger than 100-bytes").  

Also in the Microsoft.Azure.DocumentDB.Core nuget package you have to specifically request for "Version = PartitionKeyDefinitionVersion.V2" when using the CreateDocumentCollectionIfNotExistsAsync method otherwise a V1 partition key is created.

If you do not request V2 or V1 using CreateDocumentCollectionIfNotExistsAsync in DocumentCollection.PartitionKey.Version is null instead of V1 or V2 which is also confusing.  But that is a seperate issue.